### PR TITLE
Fix installation issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*__pycache__/
+grapl/parser.out
+grapl/parsetab.py

--- a/grapl/algorithms.py
+++ b/grapl/algorithms.py
@@ -7,7 +7,6 @@ by acyclic directed mixed graphs (ADMGs).
 2019, "Causal bootstrapping", arXiv:1910.09648
 """
 
-import grapl.admg as admg
 import grapl.expr as expr
 import grapl.util as util
 import copy as cp

--- a/grapl/dsl.py
+++ b/grapl/dsl.py
@@ -22,8 +22,8 @@ The terminal identifiers are:
 2019, "Causal bootstrapping", arXiv:1910.09648
 """
 
-import ply.lex as lex
-import ply.yacc as yacc
+import grapl.ply.lex as lex
+import grapl.ply.yacc as yacc
 import grapl.admg as admg
 import copy
 

--- a/grapl/util.py
+++ b/grapl/util.py
@@ -6,10 +6,6 @@ Various utility functions for the GRAPL library.
 2019, "Causal bootstrapping", arXiv:1910.09648
 """
 
-import grapl.admg as admg
-import ply.lex as lex
-import ply.yacc as yacc
-
 def csepstr(nodes):
     """Create a comma-separated string for a given list of nodes."""
     return ','.join(str(s) for s in nodes)


### PR DESCRIPTION
Tweaks `ply` imports to be `grapl.ply` instead of just `ply`.


 Whilst working on this I realised that there were some imports that were not being used so I removed them and included a `gitingore` file. 